### PR TITLE
Add missing pip install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,7 @@ usage()
 build_soc_configuration()
 {
       cd "$GITHUB_WORKSPACE"/design/mgmt_core_wrapper/litex
+      pip install -r requirements.txt
       make mgmt_soc
       cp csr.json "$GITHUB_WORKSPACE"/artifacts
       cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
I believe this is a bug? When I tried to run the commands, I was missing packages. I noticed this in the original script and added this back, and now it's running again.